### PR TITLE
Add mode "skip" to swupload. Allows the upload to skip existing objects 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: swift
-Version: 0.0.14
+Version: 0.0.15
 Title: Access 'swift' storage buckets
 Authors@R: person("Martin", "Morgan", email="mtmorgan@fredhutch.org",
     role=c("aut", "cre"))

--- a/R/stop_for.R
+++ b/R/stop_for.R
@@ -13,6 +13,10 @@
     function(container, objects, mode, paths)
 {
     exist <- swexists(container, objects)
+    if(mode%in%"skip"){
+	idx<-which(!exist)
+	return(idx)
+    }
     if ((!"replace" %in% mode) && any(exist)) {
         idx <- head(which(exist))
         stop(sum(exist), " object(s) already exist and 'mode' is not 'replace'",

--- a/R/swupload.R
+++ b/R/swupload.R
@@ -12,7 +12,7 @@
 }
 
 swupload <-
-    function(container, path=".", ..., prefix, mode=c("create", "replace"),
+    function(container, path=".", ..., prefix, mode=c("create", "replace", "skip"),
              verbose=TRUE)
 {
     stopifnot(.isString(container))
@@ -42,8 +42,16 @@ swupload <-
     objects <- sub(pattern, prefix, paths)
 
     .stop_for_upload_size(file.info(paths)$size, paths)
-    .stop_for_writable(container, objects, mode, paths)
-
+    idx<-.stop_for_writable(container, objects, mode, paths)
+    if(mode%in%"skip"){
+      if(length(idx)!=0)
+	      objects<-objects[idx]
+      else {
+        message("All objects already uploaded")
+        return(invisible())
+      }
+    }
+    
     curl <- RCurl::getCurlHandle()
     hdr <- .swauth(curl)
 

--- a/man/swupload.Rd
+++ b/man/swupload.Rd
@@ -7,7 +7,7 @@
 
 }
 \usage{
-swupload(container, path=".", ..., prefix, mode=c("create", "replace"),
+swupload(container, path=".", ..., prefix, mode=c("create", "replace", "skip"),
     verbose=TRUE)
 }
 
@@ -27,7 +27,7 @@ swupload(container, path=".", ..., prefix, mode=c("create", "replace"),
 
   \item{mode}{(Optional) A character(1) indicating whether uploaded
     objects must not already exist (\code{"create"}) or existing objects
-    can be replaced (\code{"replace"}).}
+    can be replaced (\code{"replace"}), or existing objects may be skipped (\code{"skip"}.}
 
   \item{verbose}{A logical(1) specifying level of information provided
     during function evaluation.}


### PR DESCRIPTION
Hi, Martin. 
## We're testing out the swift R client for some of our larger data sets. Description of the change is below.

Add mode "skip" to swupload. Allows the upload to skip existing objects in a container.

Helpful when performing uploads of many files as the number of open textConnections reaches the limit and errors out before completion (possible bug?).  The user needs to call closeAllConnections before proceeding. "skip" allows the upload to resume where it left off.
